### PR TITLE
Node version 4 compatibility with Jest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,4 @@ matrix:
   allow_failures:
     - node_js: '0.10'
     - node_js: '0.12'
-    - node_js: '4'
 script: npm run prepare

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",
     "babel-eslint": "8.0.1",
+    "babel-jest": "21.2.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "1.6.1",
     "eslint": "4.9.0",
@@ -50,6 +51,7 @@
     "eslint-plugin-react": "7.4.0",
     "jest": "^21.2.1",
     "npm-check": "5.4.5",
+    "regenerator-runtime": "0.11.0",
     "rimraf": "2.6.2",
     "run-sequence": "2.2.0"
   },


### PR DESCRIPTION
Reference: [Using Babel with Jest](https://github.com/facebook/jest#using-babel)

- add dev packages `babel-jest` and `regenerator-runtime`
- remove node version 4 from allow failures list in .travis.yml