### PR TITLE
remove regenerator-runtime as it is not required.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "eslint-plugin-react": "7.4.0",
     "jest": "^21.2.1",
     "npm-check": "5.4.5",
-    "regenerator-runtime": "0.11.0",
     "rimraf": "2.6.2",
     "run-sequence": "2.2.0"
   },


### PR DESCRIPTION
I have tested on node version 4, we can remove it as of now. 