### PR TITLE
fix #9 add codecov 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ matrix:
   allow_failures:
     - node_js: '0.10'
     - node_js: '0.12'
-script: npm run prepare
+script:
+  - npm run prepare
+  - npm run test -- --coverage && codecov

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/veasy.svg)](https://badge.fury.io/js/veasy)
 [![npm](https://img.shields.io/npm/l/express.svg)](https://www.npmjs.com/package/veasy)
+[![Codecov](https://img.shields.io/codecov/c/github/codecov/example-python.svg)](https://github.com/Albert-Gao/modern-es6-npm-boilerplate)
 [![Build Status](https://travis-ci.org/Albert-Gao/modern-es6-npm-boilerplate.svg?branch=master)](https://travis-ci.org/Albert-Gao/modern-es6-npm-boilerplate)
 
 A template which you could use to write your NPM package via ES6 syntax.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ We currently have 3 badges here:
 
 - Version: Generate your own at [https://badge.fury.io/](https://badge.fury.io/)
 - Licence: Generate your own at [http://shields.io/](http://shields.io/)
+- Codecov: Generate your own at [http://shields.io/](http://shields.io/)
 - Building status: If you travis, open your project there, there should be badge at the top part, click it to get your own.
 
 ## About travis

--- a/README.md
+++ b/README.md
@@ -38,11 +38,10 @@ Just added 1 more:
 
 ## Badges
 
-We currently have 3 badges here:
+We currently have 4 badges here:
 
 - Version: Generate your own at [https://badge.fury.io/](https://badge.fury.io/)
-- Licence: Generate your own at [http://shields.io/](http://shields.io/)
-- Codecov: Generate your own at [http://shields.io/](http://shields.io/)
+- Licence and Codecov: Generate your own at [http://shields.io/](http://shields.io/)
 - Building status: If you travis, open your project there, there should be badge at the top part, click it to get your own.
 
 ## About travis

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-jest": "21.2.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "1.6.1",
+    "codecov": "3.0.0",
     "eslint": "4.11.0",
     "eslint-config-airbnb": "16.1.0",
     "eslint-config-prettier": "2.7.0",


### PR DESCRIPTION
Link to codecov : https://codecov.io/gh/Albert-Gao/modern-es6-npm-boilerplate

Link to coverage for this commit: https://codecov.io/github/Albert-Gao/modern-es6-npm-boilerplate/commit/21a2affc5fe914ae4d391993da8a2f7b5a802074

example repo by codecov - https://github.com/codecov/example-node